### PR TITLE
admb -p for portable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,22 @@ Release Goals
 * Continually streamline installation and build process
 * Continually improve and update documentation
 
+Development Version
+-------------------
+
+#### New Features
+
+* New user compilation option `-p` to build a portable (statically linked) model
+  executable, which runs independently of underlying system libraries. For
+  example, if one Linux machine has system library GLIBC 2.29 and another has
+  GLIBC 2.28, users can now compile with
+
+  ```
+  admb -p simple
+  ```
+
+  to produce an executable that can run on both machines.
+
 ADMB-12.1
 ---------
 

--- a/scripts/admb/admb
+++ b/scripts/admb/admb
@@ -11,13 +11,14 @@ Builds AD Model Builder executable or library.
 Release Version: 12.1
 Location: $BASH_SOURCE
 
-Usage: admb [-c] [-d] [-f] [-g] [-r] model [src(s)]
+Usage: admb [-c] [-d] [-f] [-g] [-p] [-r] model [src(s)]
 
 Options:
  -c     Build only object file(s) (.obj).
  -d     Build a shared library (.so).
  -f     Build with fast optimized mode library (no bounds checking).
  -g     Build with debug symbols.
+ -p     Build portable model executable (statically linked).
  -r     Build with random effects library (ADMB-RE).
  model  TPL file, i.e. 'simple.tpl' or 'simple' with no .tpl extension.
  src(s) C/C++ source file(s) containing classes, methods and variables.
@@ -60,8 +61,9 @@ dll=
 library=safe
 debug=
 output=
+static=
 parser=
-while getopts "cdfgo:rs" A; do
+while getopts "cdfgo:prs" A; do
   case $A in
     c)
        compileonly=yes
@@ -78,6 +80,8 @@ while getopts "cdfgo:rs" A; do
        ;;
     o)
        output="$OPTARG"
+       ;;
+    p) static=-static
        ;;
     r)
        parser=tpl2rem
@@ -299,7 +303,7 @@ if [[ -f "$ADMB_HOME/lib/libadmb-contrib-$CXXVERSION$SHARED.a" || -f "$ADMB_HOME
 else
   CXXFLAGS="$CXXFLAGS -I. -I\"$ADMB_HOME/include\""
 fi
-if [ "$CXX" == "adcomp-x86_64-w64-mingw32" ]; then
+if [[ "$static" == "-static" || "$CXX" == "adcomp-x86_64-w64-mingw32" ]]; then
   LDFLAGS="--static $LDFLAGS"
 fi
 tplsrcs=

--- a/scripts/admb/admb
+++ b/scripts/admb/admb
@@ -11,19 +11,16 @@ Builds AD Model Builder executable or library.
 Release Version: 12.1
 Location: $BASH_SOURCE
 
-Usage: admb [-c] [-d] [-g] [-r] [-f] model [src(s)]
+Usage: admb [-c] [-d] [-f] [-g] [-r] model [src(s)]
 
 Options:
  -c     Build only object file(s) (.obj).
  -d     Build a shared library (.so).
+ -f     Build with fast optimized mode library (no bounds checking).
  -g     Build with debug symbols.
- -r     Build with Random effects library (ADMB-RE).
- -f     Build with Fast optimized mode library (no bounds checking).
-        By default, admb script builds with bounds checking.
- model  TPL file (ie 'simple.tpl' or the filename 'simple' with no .tpl
-        extension)
- src(s) C/C++ Source file(s) containing classes, methods and variables that
-        are used in model.
+ -r     Build with random effects library (ADMB-RE).
+ model  TPL file, i.e. 'simple.tpl' or 'simple' with no .tpl extension.
+ src(s) C/C++ source file(s) containing classes, methods and variables.
 "'
 
 if [[ "$1" == "" ]]; then help; exit; fi
@@ -58,39 +55,34 @@ fi
 PATH=$ADMB_HOME/bin:$PATH
 
 # Pop args until model=$1
-unset dll
-unset debug
-unset parser
-unset library
-unset compileonly
-dll=
-debug=
-parser=
-library=safe
 compileonly=
+dll=
+library=safe
+debug=
 output=
-while getopts "dgrsfco:" A; do
+parser=
+while getopts "cdfgo:rs" A; do
   case $A in
+    c)
+       compileonly=yes
+       ;;
     d)
        dll=-dll
        SHARED=-shared
        ;;
+    f)
+       library=opt
+       ;;
     g)
        debug=-debug
+       ;;
+    o)
+       output="$OPTARG"
        ;;
     r)
        parser=tpl2rem
        ;;
     s)
-       ;;
-    f)
-       library=opt
-       ;;
-    c)
-       compileonly=yes
-       ;;
-    o)
-       output="$OPTARG"
        ;;
     *)
        help

--- a/scripts/admb/admb.bat
+++ b/scripts/admb/admb.bat
@@ -641,6 +641,7 @@ echo  -c     Build only object file(s) (.obj).
 echo  -d     Build a dynamic library (.dll).
 echo  -f     Build with fast optimized mode library (no bounds checking).
 echo  -g     Build with debug symbols.
+echo  -p     Build portable model executable (-p has no effect in Windows).
 echo  -r     Build with random effects library (ADMB-RE).
 echo  model  TPL file, i.e. 'simple.tpl' or 'simple' with no .tpl extension.
 echo  src(s) C/C++ source file(s) containing classes, methods and variables.

--- a/scripts/admb/admb.bat
+++ b/scripts/admb/admb.bat
@@ -61,15 +61,15 @@ for %%a in (%*) do (
     if "!arg!"=="-d" (
       set d= -d
     )
+    if "!arg!"=="-f" (
+      set fast= -f
+    )
     if "!arg!"=="-g" (
       set g= -g
     )
     if "!arg!"=="-r" (
       set r = -r
       set parser=tpl2rem
-    )
-    if "!arg!"=="-f" (
-      set fast= -f
     )
   ) else (
     if "%%~xa"=="" (
@@ -634,19 +634,16 @@ echo.
 echo Release Version: 12.1
 echo Location: %~dp0
 echo.
-echo Usage: admb [-c] [-d] [-g] [-r] [-f] model [src(s)]
+echo Usage: admb [-c] [-d] [-f] [-g] [-r] model [src(s)]
 echo.
 echo Options:
 echo  -c     Build only object file(s) (.obj).
 echo  -d     Build a dynamic library (.dll).
+echo  -f     Build with fast optimized mode library (no bounds checking).
 echo  -g     Build with debug symbols.
-echo  -r     Build Random effects library (ADMB-RE).
-echo  -f     Build with Fast optimized mode library (no error checking).
-echo         By default, admb script will include error checking in the build.
-echo  model  TPL file (ie 'simple.tpl' or the filename 'simple' with no .tpl
-echo         extension)
-echo  src(s) C/C++ Source file(s) containing classes, methods and variables that
-echo         are used in model.
+echo  -r     Build with random effects library (ADMB-RE).
+echo  model  TPL file, i.e. 'simple.tpl' or 'simple' with no .tpl extension.
+echo  src(s) C/C++ source file(s) containing classes, methods and variables.
 echo.
 goto EOF
 REM r982 [2011-02-16] arnima  rewrite, fixed bug when user option is not


### PR DESCRIPTION
* New user compilation option `-p` to build a portable (statically linked) model
  executable, which runs independently of underlying system libraries. For
  example, if one Linux machine has system library GLIBC 2.29 and another has
  GLIBC 2.28, users can now compile with

  ```
  admb -p simple
  ```

  to produce an executable that can run on both machines.
