### PR TITLE
Reduce noise in new console output

### DIFF
--- a/src/linad99/newfmin.cpp
+++ b/src/linad99/newfmin.cpp
@@ -1025,15 +1025,11 @@ if (iprint>0)
        cout << "Optimization completed after "
             << get_elapsed_time(start_time, std::chrono::system_clock::now())
             << " with final statistics:\n" ;
-       ad_printf(" nll=%f | mag=%.5e | par[%3d]=%s\n", double(f), fabs(double(gmax)), maxpar, (char*)pars(maxpar));
-    
+       ad_printf("  nll=%f | mag=%.5e | par[%3d]=%s\n\n", double(f), fabs(double(gmax)), maxpar, (char*)pars(maxpar));
+
        if (initial_params::num_initial_params && function_minimizer::output_flag==1){
-	 cout << "\nChecking for estimated parameters on bounds...";
 	 check_for_params_on_bounds(std::cout);
-	 //  std::ofstream os("parameters_on_bounds.txt", std::ofstream::out|std::ofstream::trunc);
-	 *ad_comm::global_logfile << "\nChecking for estimated parameters on bounds...";
 	 check_for_params_on_bounds(*ad_comm::global_logfile);
-	 //os.close();
        }
      }
    }

--- a/src/nh99/mod_hess.cpp
+++ b/src/nh99/mod_hess.cpp
@@ -552,7 +552,6 @@ void function_minimizer::depvars_routine(void)
   }
   gradient_structure::get()->jacobcalc(nvar,ofs);
   for (i=0;i<ndvarcals;i++)
-  for (i=0;i< stddev_params::num_stddev_params;i++)
   {
      ofs << stddev_params::stddevptr[i]->label() << "  ";
      ofs << stddev_params::stddevptr[i]->size_count() << endl;

--- a/src/nh99/mod_hess.cpp
+++ b/src/nh99/mod_hess.cpp
@@ -576,15 +576,6 @@ bool function_minimizer::hess_inv(void)
   independent_variables x(1,nvar);
 
   std::chrono::time_point<std::chrono::system_clock> from_start;
-  if (function_minimizer::output_flag == 1)
-  {
-    from_start = std::chrono::system_clock::now();
-
-    cout << "Inverting Hessian";
-    if (nvar >= 10) cout << " (" << nvar << " variables)";
-    cout << ": ";
-    cout.flush();
-  }
 
   initial_params::xinit(x);        // get the initial values into the x vector
   //double f;
@@ -636,24 +627,6 @@ bool function_minimizer::hess_inv(void)
       if (tmp1>maxerr) maxerr=tmp1;
       hess(i,j)=tmp;
       hess(j,i)=tmp;
-    }
-    if (function_minimizer::output_flag == 1)
-    {
-      if(nvar >= 10)
-      {
-        if (i == index)
-        {
-          if (percentage > defaults::percentage) cout << ", ";
-          cout << percentage << "%";
-          percentage += 20;
-          index += num;
-        }
-      }
-      else
-      {
-        if (i > 1) cout << ", ";
-        cout << i;
-      }
     }
   }
   /*
@@ -816,10 +789,6 @@ bool function_minimizer::hess_inv(void)
       ofs << gradient_structure::Hybrid_bounded_flag;
       ofs << sscale;
     }
-  }
-  if (function_minimizer::output_flag == 1)
-  {
-    print_elapsed_time(from_start, std::chrono::system_clock::now());
   }
   return true;
 }

--- a/src/nh99/mod_hess.cpp
+++ b/src/nh99/mod_hess.cpp
@@ -505,7 +505,6 @@ void function_minimizer::depvars_routine(void)
     from_start = std::chrono::system_clock::now();
 
     cout << "Differentiating " << ndvarcals << " derived quantities: ";
-    if (ndvarcals >= 10) cout << "%";
   }
   independent_variables x(1,nvar);
   initial_params::xinit(x);        // get the initial values into the x vector
@@ -529,9 +528,9 @@ void function_minimizer::depvars_routine(void)
   ofs << nvar << "  "  << ndvar << endl;
   int i;
   int percentage = defaults::percentage;
-  const int num = nvar / 5;
-  int index = num + (nvar % 5);
-  for (i=0;i< stddev_params::num_stddev_params;i++)
+  const int num = ndvarcals / 5;
+  int index = num + (ndvarcals % 5);
+  for (i=0;i<ndvarcals;i++)
   {
     if (function_minimizer::output_flag == 1)
     {
@@ -552,6 +551,7 @@ void function_minimizer::depvars_routine(void)
       stddev_params::stddevptr[i]->set_dependent_variables();
   }
   gradient_structure::get()->jacobcalc(nvar,ofs);
+  for (i=0;i<ndvarcals;i++)
   for (i=0;i< stddev_params::num_stddev_params;i++)
   {
      ofs << stddev_params::stddevptr[i]->label() << "  ";

--- a/src/nh99/mod_sd.cpp
+++ b/src/nh99/mod_sd.cpp
@@ -100,13 +100,6 @@ void print_elapsed_time(
 
 void function_minimizer::sd_routine(void)
 {
-  std::chrono::time_point<std::chrono::system_clock> from_start;
-  if (function_minimizer::output_flag == 1)
-  {
-    from_start = std::chrono::system_clock::now();
-    cout << "Starting standard error calculations... " ;
-  }
-
   int nvar=initial_params::nvarcalc(); // get the number of active parameters
   dvector x(1,nvar);
   initial_params::xinit(x); // get the number of active parameters
@@ -561,10 +554,5 @@ void function_minimizer::sd_routine(void)
   {
     char msg[40] = {"Error trying to delete temporary file "};
     cerr << msg << "admodel.tmp" << endl;
-  }
-
-  if (function_minimizer::output_flag == 1)
-  {
-    print_elapsed_time(from_start, std::chrono::system_clock::now());
   }
 }

--- a/src/nh99/mod_sd.cpp
+++ b/src/nh99/mod_sd.cpp
@@ -85,7 +85,7 @@ std::string get_elapsed_time(
     runtime/=(24*60*60); u=" days";
   }
   runtime=std::round(runtime * 10.0) / 10.0;
-  cout << " done! (" << runtime  << u << ")" <<  endl;
+  cout << " done (" << runtime  << u << ")" <<  endl;
 */
 
   return std::move(ss.str());
@@ -95,7 +95,7 @@ void print_elapsed_time(
   const std::chrono::time_point<std::chrono::system_clock>& from,
   const std::chrono::time_point<std::chrono::system_clock>& to)
 {
-  cout << " done! (" << get_elapsed_time(from, to) << ") " << endl;
+  cout << " done (" << get_elapsed_time(from, to) << ") " << endl;
 }
 
 void function_minimizer::sd_routine(void)

--- a/src/nh99/output_checks.cpp
+++ b/src/nh99/output_checks.cpp
@@ -316,18 +316,18 @@ void check_for_params_on_bounds(ostream& os){
 	    adstring par_name = par_name_base;
 	    if (debug) os<<"   "<<par_name<<": "<<minb<<" < "<<valp<<" < "<<maxb<<"?"<<endl;
 	    if ((valp-minb)/(maxb-minb)<0.001) {
-	      if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-	      os<<"   "<<par_name<<" is within 0.1\% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+	      if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+	      os<<"  "<<par_name<<" is within 0.1\% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	    } else if ((valp-minb)/(maxb-minb)<0.01) {
-	      if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-	      os<<"   "<<par_name<<" is within 1% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+	      if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+	      os<<"  "<<par_name<<" is within 1% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	    }
 	    if ((maxb-valp)/(maxb-minb)<0.001) {
-	      if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-	      os<<"   "<<par_name<<" is within 0.1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+	      if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+	      os<<"  "<<par_name<<" is within 0.1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	    } else if ((maxb-valp)/(maxb-minb)<0.01) {
-	      if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-	      os<<"   "<<par_name<<" is within 1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+	      if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+	      os<<"  "<<par_name<<" is within 1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	    }
 	  } else if (dynamic_cast<param_init_bounded_dev_vector*>(varptr) != nullptr) {
 	    if (debug) os<<"   "<<par_name_base<<" is a param_init_bounded_dev_vector with "<<jmax<<" elements."<<endl;
@@ -339,22 +339,22 @@ void check_for_params_on_bounds(ostream& os){
 	      adstring par_name = par_name_base+"["+str(j)+"]";
 	      if (debug) os<<"   "<<par_name<<": "<<minb<<" < "<<valp<<" < "<<maxb<<"?"<<endl;
 	      if ((valp-minb)/(maxb-minb)<0.001) {
-		if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-		os<<"   "<<par_name<<" is within 0.1\% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		os<<"  "<<par_name<<" is within 0.1\% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      } else if ((valp-minb)/(maxb-minb)<0.01) {
-		if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-		os<<"   "<<par_name<<" is within 1% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		os<<"  "<<par_name<<" is within 1% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      }
 	      if ((maxb-valp)/(maxb-minb)<0.001) {
-		if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-		os<<"   "<<par_name<<" is within 0.1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		os<<"  "<<par_name<<" is within 0.1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      } else if ((maxb-valp)/(maxb-minb)<0.01) {
-		if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-		os<<"   "<<par_name<<" is within 1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		os<<"  "<<par_name<<" is within 1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      }
 	    }//-j
 	  } else if (dynamic_cast<param_init_bounded_vector*>(varptr) != nullptr) {
-	    if (debug) os<<"   "<<par_name_base<<" is a param_init_bounded_vector with "<<jmax<<" elements."<<endl;
+	    if (debug) os<<"  "<<par_name_base<<" is a param_init_bounded_vector with "<<jmax<<" elements."<<endl;
 	    param_init_bounded_vector* p = dynamic_cast<param_init_bounded_vector*>(varptr);
 	    double minb = p->get_minb();
 	    double maxb = p->get_maxb();
@@ -363,18 +363,18 @@ void check_for_params_on_bounds(ostream& os){
 	      adstring par_name = par_name_base+"["+str(j)+"]";
 	      if (debug) os<<"   "<<par_name<<": "<<minb<<" < "<<valp<<" < "<<maxb<<"?"<<endl;
 	      if ((valp-minb)/(maxb-minb)<0.001) {
-		if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-		os<<"   "<<par_name<<" is within 0.1\% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		os<<"  "<<par_name<<" is within 0.1\% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      } else if ((valp-minb)/(maxb-minb)<0.01) {
-		if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-		os<<"   "<<par_name<<" is within 1% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		os<<"  "<<par_name<<" is within 1% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      }
 	      if ((maxb-valp)/(maxb-minb)<0.001) {
-		if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-		os<<"   "<<par_name<<" is within 0.1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		os<<"  "<<par_name<<" is within 0.1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      } else if ((maxb-valp)/(maxb-minb)<0.01) {
-		if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-		os<<"   "<<par_name<<" is within 1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		os<<"  "<<par_name<<" is within 1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      }
 	    }//-j
 	  } else if (dynamic_cast<param_init_bounded_matrix*>(varptr)!=nullptr) {
@@ -389,18 +389,18 @@ void check_for_params_on_bounds(ostream& os){
 		double valp = ::value(v[k]);
 		if (debug) os<<"   "<<par_name<<": "<<minb<<" < "<<valp<<" < "<<maxb<<"?"<<endl;
 		if ((valp-minb)/(maxb-minb)<0.001) {
-		  if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-		  os<<"   "<<par_name<<" is within 0.1\% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+		  if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		  os<<"  "<<par_name<<" is within 0.1\% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 		} else if ((valp-minb)/(maxb-minb)<0.01) {
-		  if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-		  os<<"   "<<par_name<<" is within 1% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+		  if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		  os<<"  "<<par_name<<" is within 1% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 		}
 		if ((maxb-valp)/(maxb-minb)<0.001) {
-		  if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-		  os<<"   "<<par_name<<" is within 0.1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+		  if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		  os<<"  "<<par_name<<" is within 0.1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 		} else if ((maxb-valp)/(maxb-minb)<0.01) {
-		  if(counter==0){os << endl << "  Warning: the following parameters had issues:" << endl; counter++;}
-		  os<<"   "<<par_name<<" is within 1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
+		  if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		  os<<"  "<<par_name<<" is within 1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 		}
 	      }//-k
 	    }//-j
@@ -416,12 +416,5 @@ void check_for_params_on_bounds(ostream& os){
     if (debug) os<<"--Model appears to be autodiff only: no bounds checking performed."<<endl;
   }
   if (debug) os<<"Finished initial_params::check_parameters_on_bounds"<<endl;
-  if(counter==0){
-    os << " none found!" << endl;
-  } else {
-    os << " done!" << endl;
-  }
+  if (counter > 0) os << endl;
 }
-
-
-

--- a/src/nh99/output_checks.cpp
+++ b/src/nh99/output_checks.cpp
@@ -316,17 +316,17 @@ void check_for_params_on_bounds(ostream& os){
 	    adstring par_name = par_name_base;
 	    if (debug) os<<"   "<<par_name<<": "<<minb<<" < "<<valp<<" < "<<maxb<<"?"<<endl;
 	    if ((valp-minb)/(maxb-minb)<0.001) {
-	      if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+	      if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 	      os<<"  "<<par_name<<" is within 0.1\% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	    } else if ((valp-minb)/(maxb-minb)<0.01) {
-	      if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+	      if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 	      os<<"  "<<par_name<<" is within 1% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	    }
 	    if ((maxb-valp)/(maxb-minb)<0.001) {
-	      if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+	      if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 	      os<<"  "<<par_name<<" is within 0.1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	    } else if ((maxb-valp)/(maxb-minb)<0.01) {
-	      if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+	      if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 	      os<<"  "<<par_name<<" is within 1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	    }
 	  } else if (dynamic_cast<param_init_bounded_dev_vector*>(varptr) != nullptr) {
@@ -339,17 +339,17 @@ void check_for_params_on_bounds(ostream& os){
 	      adstring par_name = par_name_base+"["+str(j)+"]";
 	      if (debug) os<<"   "<<par_name<<": "<<minb<<" < "<<valp<<" < "<<maxb<<"?"<<endl;
 	      if ((valp-minb)/(maxb-minb)<0.001) {
-		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 		os<<"  "<<par_name<<" is within 0.1\% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      } else if ((valp-minb)/(maxb-minb)<0.01) {
-		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 		os<<"  "<<par_name<<" is within 1% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      }
 	      if ((maxb-valp)/(maxb-minb)<0.001) {
-		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 		os<<"  "<<par_name<<" is within 0.1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      } else if ((maxb-valp)/(maxb-minb)<0.01) {
-		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 		os<<"  "<<par_name<<" is within 1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      }
 	    }//-j
@@ -363,17 +363,17 @@ void check_for_params_on_bounds(ostream& os){
 	      adstring par_name = par_name_base+"["+str(j)+"]";
 	      if (debug) os<<"   "<<par_name<<": "<<minb<<" < "<<valp<<" < "<<maxb<<"?"<<endl;
 	      if ((valp-minb)/(maxb-minb)<0.001) {
-		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 		os<<"  "<<par_name<<" is within 0.1\% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      } else if ((valp-minb)/(maxb-minb)<0.01) {
-		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 		os<<"  "<<par_name<<" is within 1% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      }
 	      if ((maxb-valp)/(maxb-minb)<0.001) {
-		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 		os<<"  "<<par_name<<" is within 0.1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      } else if ((maxb-valp)/(maxb-minb)<0.01) {
-		if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 		os<<"  "<<par_name<<" is within 1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 	      }
 	    }//-j
@@ -389,17 +389,17 @@ void check_for_params_on_bounds(ostream& os){
 		double valp = ::value(v[k]);
 		if (debug) os<<"   "<<par_name<<": "<<minb<<" < "<<valp<<" < "<<maxb<<"?"<<endl;
 		if ((valp-minb)/(maxb-minb)<0.001) {
-		  if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		  if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 		  os<<"  "<<par_name<<" is within 0.1\% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 		} else if ((valp-minb)/(maxb-minb)<0.01) {
-		  if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		  if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 		  os<<"  "<<par_name<<" is within 1% of lower bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 		}
 		if ((maxb-valp)/(maxb-minb)<0.001) {
-		  if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		  if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 		  os<<"  "<<par_name<<" is within 0.1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 		} else if ((maxb-valp)/(maxb-minb)<0.01) {
-		  if(counter==0){os << "Warning: the following parameters had issues:" << endl; counter++;}
+		  if(counter==0){os << "Warning: the following parameters had issues" << endl; counter++;}
 		  os<<"  "<<par_name<<" is within 1\% of upper bound: "<<minb<<" < "<<valp<<" < "<<maxb<<endl;
 		}
 	      }//-k

--- a/src/nh99/output_checks.cpp
+++ b/src/nh99/output_checks.cpp
@@ -198,7 +198,7 @@ void function_minimizer::hess_step(){
       depvars_routine(); // calculate derivatives of sdreport variables
       hess_inv(); // Invert Hess and write to admodel.cov
       function_minimizer::output_flag=oldoutput;
-      cout << "done!" << endl;
+      cout << "done" << endl;
     }
   } // end loop over hess_steps
   
@@ -221,7 +221,7 @@ void function_minimizer::hess_step(){
     function_minimizer::output_flag=0;
     computations1(ad_comm::argc,ad_comm::argv);
     function_minimizer::output_flag=oldoutput;
-    cout << " done!" << endl;
+    cout << " done" << endl;
     cout << endl << "The " << Nstep << " Hessian step(s) reduced maxgrad from " <<
       maxgrad0 << " to " << maxgrad2 << " and NLL by " << nll-nll2 << "." << endl <<
       "All output files should be updated, but confirm as this is experimental still." << endl <<


### PR DESCRIPTION
The new console output is fantastic: a compact summary of the estimation phases and final fit, with single-line progress bars for uncertainty calculations at the end. Identifying parameters that have a large gradient or are near the bound is especially useful.

After testing the new console output on a wide variety of examples, my only criticism is that it's slightly too noisy near the end. Even after training my eyes on the new format, there's just too many progress bars and exclamations, making it difficult to read the important bits.

With this pull request, I would like to propose the following three modifications that reduce noise in the new console output:

1. The warning paragraph about parameters near the bound should only be shown when it occurs. Think of glm() in R, which sometimes shows important warnings. It would be considered unnecessarily verbose to display a line in the midst of the GLM standard output saying "no warnings this time". Simply not showing a warning seems like a good way to show there is no warning.

2. It seems like it should be enough to have two progress meters for the uncertainty calculations at the end. The tasks of (1) calculating the Hessian and (2) differentiating the derived quantities [Jacobian] can each take about as long as estimating the parameters, so it's insightful to see that breakdown: 10 sec, 9 sec, 11 sec. On the other hand, the tasks of (3) inverting the Hessian and the (4) standard error calculations take a tiny fraction of a second so those progress meters can probably be removed to keep the standard output relevant and to the point.

3. Finally, a couple of cosmetic changes, removing the second colon from "Warning: the following parameters had issues:" and removing the exclamation marks (!) at the end of the progress meters. It seems that the use of exclamation marks is appropriate when something unusual and bad happens, requiring the immediate attention of the user.

I also include the two commits from bug fix #247 (which should probably be merged first) to avoid merge conflicts.