### PR TITLE
allow compiling admb with 'g++-12'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,3 +360,43 @@ bcc-install:
 	cd src& $(MAKE) -fbcc.mak install
 bcc-clean:
 	cd src& $(MAKE) -fbcc.mak clean
+
+#GNU
+g++-x: g++-x-all
+g++-x-all:
+	$(MAKE) g++-x-dist
+	$(MAKE) g++-x-shared
+	$(MAKE) --directory=src CC=$(CC) CXX=$(CXX) copy
+g++-x-dist:
+	$(MAKE) g++-x-core
+	$(MAKE) g++-x-contribs
+g++-x-debug:
+	$(MAKE) g++-x-all DEBUG=yes
+g++-x-core:
+	$(MAKE) --directory=src CC=$(CC) CXX=$(CXX) all
+g++-x-contribs: g++-x-core
+	$(MAKE) --directory=contrib CC=$(CC) CXX=$(CXX) all
+g++-x-docs:
+	$(MAKE) --directory=docs CC=$(CC) CXX=$(CXX) all
+g++-x-gtests:
+	$(MAKE) --directory=tests CC=$(CC) CXX=$(CXX) unit-gtests
+g++-x-coverage:
+	$(MAKE) --directory=src CC=$(CC) CXX=$(CXX) SAFE_ONLY=yes dist
+	$(MAKE) --directory=tests CC=$(CC) CXX=$(CXX) coverage
+g++-x-verify:
+	$(MAKE) --directory=tests CC=$(CC) CXX=$(CXX) verify
+g++-x-shared:
+	$(MAKE) --directory=src CC=$(CC) CXX=$(CXX) SHARED=-shared shared
+	$(MAKE) --directory=contrib CC=$(CC) CXX=$(CXX) SHARED=-shared shared
+g++-x-install:
+	$(MAKE) --directory=src CC=$(CC) CXX=$(CXX) install
+g++-x-check:
+	$(MAKE) --directory=src CC=$(CC) CXX=$(CXX) check
+g++-x-clean:
+	$(MAKE) --directory=src CC=$(CC) CXX=$(CXX) clean
+	$(MAKE) --directory=contrib CC=$(CC) CXX=$(CXX) clean
+	$(MAKE) --directory=scripts CC=$(CC) CXX=$(CXX) clean
+	$(MAKE) --directory=tests CC=$(CC) CXX=$(CXX) clean
+	$(MAKE) --directory=examples CC=$(CC) CXX=$(CXX) clean
+g++-x-zip:
+	$(MAKE) --directory=src CC=$(CC) CXX=$(CXX) zip

--- a/contrib/GNUmakefile
+++ b/contrib/GNUmakefile
@@ -94,7 +94,8 @@ else
       endif
     endif
   endif
-  ifeq ($(CXX),g++)
+  #ifeq ($(CXX),g++)
+  ifeq (g++, $(findstring g++, $(CXX)))
     ifeq ($(UNAME_S),Darwin)
       ifeq (clang-10,$(findstring clang-10,$(shell $(CXX) --version)))
         CXXVERSION=-clang10

--- a/scripts/admb/admb
+++ b/scripts/admb/admb
@@ -180,7 +180,7 @@ if [[ "$UNAME_S" =~ "_NT" ]]; then
     fi
   fi
 fi
-if [ "$CXX" == "g++" ]; then
+if [[ "$CXX" =~ "g++" ]]; then
   if [ "$UNAME_S" == "Darwin" ]; then
     if [[ "`$CXX --version`" =~ "clang-11" ]]; then
       CXXVERSION=$OS_NAME-clang11
@@ -192,8 +192,13 @@ if [ "$CXX" == "g++" ]; then
       fi
     fi
   else
-    DUMPVERSION="`g++ -dumpversion | cut -f1 -d. `"
-    CXXVERSION="$OS_NAME-$CXX$DUMPVERSION"
+    if [[ "$CXX" =~ "g++-" ]]; then
+      CXXTMP=g++
+    else
+      CXXTMP=$CXX
+    fi
+    DUMPVERSION="`$CXX -dumpversion | cut -f1 -d. `"
+    CXXVERSION="$OS_NAME-$CXXTMP$DUMPVERSION"
   fi
 fi
 if [ "$CXX" == "clang++" ]; then

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -111,7 +111,8 @@ else
   ifndef OSNAME
     $(warning Unknown UNAME_S = "$(UNAME_S)" results in empty OSNAME.)
   else
-    ifeq ($(CXX),g++)
+    #ifeq ($(CXX),g++)
+    ifeq (g++,$(findstring g++, $(CXX)))
       ifeq ($(UNAME_S),Darwin)
         ifeq (clang-10,$(findstring clang-10,$(shell $(CXX) --version)))
           CXXVERSION=-clang10
@@ -210,6 +211,7 @@ endif
 
 ifeq ($(CMDSHELL),cmd)
   ifeq ($(CXX),g++)
+  #ifeq (g++, $(findstring g++, $(CXX))
     ifeq ($(findstring g++.exe,$(shell where g++.exe 2>&1 | findstr g++.exe)),g++.exe)
       GCCMAJVER:="GCCVER$(shell gcc -dumpversion)"
       ifeq (GCCVER4,$(findstring GCCVER4,$(GCCMAJVER)))
@@ -246,10 +248,10 @@ else
       endif
     else ifeq ($(CXX),CC)
       ADCXXFLAGS:= -std=c++11 $(ADCXXFLAGS)
-    else ifeq ($(CXX),g++)
-      GCCMAJVER:=$(shell gcc -dumpversion | cut -f1 -d. )
+    else ifeq (g++, $(findstring g++, $(CXX)))
+      GCCMAJVER:=$(shell $(CC) -dumpversion | cut -f1 -d. )
       ifeq ("$(GCCMAJVER)","4")
-        GCCMINVER:=$(shell gcc -dumpversion | cut -f2 -d. )
+        GCCMINVER:=$(shell $(CC) -dumpversion | cut -f2 -d. )
         ifeq ("$(GCCMINVER)","9")
           ADCXXFLAGS:= -std=c++11 $(ADCXXFLAGS)
         else
@@ -317,7 +319,7 @@ CXXFLAGS_OPT_LIB:=$(subst -D_USE_MATH_DEFINES,-DOPT_LIB -D_USE_MATH_DEFINES,$(CX
 ifeq ($(CXX),c++)
 CXXFLAGS_OPT_LIB:=$(subst -Wextra,-Wextra,$(CXXFLAGS_OPT_LIB))
 endif
-ifeq ($(CXX),g++)
+ifeq (g++, $(findstring g++, $(CXX)))
 CXXFLAGS_OPT_LIB:=$(subst -Wextra,-Wextra,$(CXXFLAGS_OPT_LIB))
 endif
 ifneq ($(CXX),CC)


### PR DESCRIPTION
This will allow to compile admb with `$(CXX)=g++-12` and more generally "g++-'Major verson'".
This is intended to resolve [it](https://github.com/admb-project/admb/issues/270#issue-1339876255).
This can be done by running
```
make g++-x CXX=g++-12 CC=gcc-12
```

