### PR TITLE
Fixes ADMB compiling on Linux arm64

### DIFF
--- a/contrib/GNUmakefile
+++ b/contrib/GNUmakefile
@@ -62,7 +62,11 @@ else
     ifeq (i686,$(findstring i686,$(shell $(CXX) -dumpmachine)))
       OSNAME=-i686-linux
     else
-      OSNAME=-x86_64-linux
+      ifeq (x86_64,$(findstring x86_64,$(shell $(CXX) -dumpmachine)))
+        OSNAME=-x86_64-linux
+      else
+        OSNAME=-arm64-linux
+      endif
     endif
   endif
   ifeq ($(UNAME_S),Darwin)


### PR DESCRIPTION
Fixes issue #277. This is a minimal change that brings the make instructions in line with `admb/src/GNUMakefile` and `admb/scripts/admb.sh`.